### PR TITLE
Add IActionLoaderProvider

### DIFF
--- a/src/common/LibplanetConsole.Common/BlockChainUtility.cs
+++ b/src/common/LibplanetConsole.Common/BlockChainUtility.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Numerics;
 using Bencodex.Types;
 using Libplanet.Action;
+using Libplanet.Action.Loader;
 using Libplanet.Action.Sys;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -27,15 +28,15 @@ public static class BlockChainUtility
         = AppProtocolVersion.Sign(AppProtocolKey, 1);
 
     public static BlockChain CreateBlockChain(
-        GenesisOptions genesisOptions, string storePath, IRenderer renderer)
+        GenesisOptions genesisOptions,
+        string storePath,
+        IRenderer renderer,
+        IActionLoader[] actionLoaders)
     {
         var genesisKey = (PrivateKey)genesisOptions.GenesisKey;
         var isNew = storePath == string.Empty || Directory.Exists(storePath) != true;
         var (store, stateStore) = GetStore(storePath);
-        var actionLoader = new AggregateTypedActionLoader
-        {
-            new AssemblyActionLoader(typeof(AssemblyActionLoader).Assembly),
-        };
+        var actionLoader = new AggregateTypedActionLoader(actionLoaders);
         var actionEvaluator = new ActionEvaluator(
             policyBlockActionGetter: _ => null,
             stateStore,

--- a/src/node/LibplanetConsole.Nodes/ApplicationBase.cs
+++ b/src/node/LibplanetConsole.Nodes/ApplicationBase.cs
@@ -29,7 +29,7 @@ public abstract class ApplicationBase : Frameworks.ApplicationBase, IApplication
         _logger.Debug(Environment.CommandLine);
         _logger.Debug("Application initializing...");
         _isAutoStart = options.ManualStart != true;
-        _node = new Node(options, _logger);
+        _node = new Node(this, options, _logger);
         _container = new(this);
         _container.ComposeExportedValue<ILogger>(_logger);
         _container.ComposeExportedValue<IApplication>(this);

--- a/src/node/LibplanetConsole.Nodes/IActionLoaderProvider.cs
+++ b/src/node/LibplanetConsole.Nodes/IActionLoaderProvider.cs
@@ -1,0 +1,8 @@
+using Libplanet.Action.Loader;
+
+namespace LibplanetConsole.Nodes;
+
+public interface IActionLoaderProvider
+{
+    IActionLoader GetActionLoader();
+}


### PR DESCRIPTION
In order to create a blockchain instance, it needs an `IActionLoader`.
Actions can exist in many different assemblies, not just one.
To collect `IActionLoaders` that can load these Actions, we implemented `IActionLoaderProvider`.
Users can implement `IActionLoaderProvider` to pass an `IActionLoader` to the blockchain instance creation.